### PR TITLE
Fix missing README.md during pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include *.txt
 include MANIFEST.in
+include README.md
 recursive-include docs *
 recursive-include currencies/locale *
 recursive-include currencies/fixtures *


### PR DESCRIPTION
README.md is not included in MANIFEST.in and so missing during pip install:

```
File "/home/noxan/test/build/django-currencies/setup.py", line 31, in <module>

  long_description=open('README.md').read()
```
