### PR TITLE
Allow a list of currency codes in the initcurrencies command

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ You will need to specify your API key in your settings file::
 
 You will then be able to use the management commands "initcurrencies" and "updatecurrencies".
 The former will create any currency that exists on openexchangerates.org with a default
-factor of 1.0. It is completely optional and does not require an API key.
+factor of 1.0. It is completely optional and does not require an API key. A list of currency codes may be supplied to
+limit the currencies that will be initialised.
 
 The updatecurrencies management command will update all your currencies against the rates
 returned by openexchangerates.org. Any missing currency will be left untouched.

--- a/currencies/management/commands/initcurrencies.py
+++ b/currencies/management/commands/initcurrencies.py
@@ -2,26 +2,33 @@ import json
 from urllib2 import urlopen
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.core.management.base import CommandError, NoArgsCommand
+from django.core.management.base import CommandError, BaseCommand
 from currencies.models import Currency
 
 CURRENCY_API_URL = "http://openexchangerates.org/currencies.json"
 
 
-class Command(NoArgsCommand):
-	help = "Create all missing currencies defined on openexchangerates.org"
+class Command(BaseCommand):
+	help = "Create all missing currencies defined on openexchangerates.org. A list of ISO 4217 codes may be supplied to limit the currencies initialised."
+	args = "<code code code code...>"
 
-	def handle_noargs(self, **options):
+	def handle(self, *args, **options):
 		print("Querying database at %s" % (CURRENCY_API_URL))
+
+		currencies = []
+		if len(args):
+			currencies = list(args)
+
 		api = urlopen(CURRENCY_API_URL)
 		d = json.loads(api.read())
 		i = 0
 
 		for currency in sorted(d.keys()):
-			if not Currency.objects.filter(code=currency):
-				print("Creating %r (%s)" % (d[currency], currency))
-				Currency(code=currency, name=d[currency], factor=1.0, is_active=False).save()
-				i+=1
+			if (not currencies) or currency in currencies:
+				if not Currency.objects.filter(code=currency):
+					print("Creating %r (%s)" % (d[currency], currency))
+					Currency(code=currency, name=d[currency], factor=1.0, is_active=False).save()
+					i+=1
 
 		if i == 1:
 			print("%i new currency" % (i))


### PR DESCRIPTION
Allow a list of currency codes in the initcurrencies command to limit the currencies that are initialised.
