### PR TITLE
Fix for #11

### DIFF
--- a/currencies/urls.py
+++ b/currencies/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import url, patterns
 from currencies.views import set_currency
 
 


### PR DESCRIPTION
`defaults` model has been dropped in Django-1.6.
