### PR TITLE
Fix UnicodeEncodeError with Django 1.8

### DIFF
--- a/currencies/models.py
+++ b/currencies/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 
 
 class CurrencyManager(models.Manager):


### PR DESCRIPTION
with Django 1.8, access /admin/currencies/currency would throw UnicodeEncodeError.

modifie models.py use ugettext_lazy replace gettext_lazy