### PR TITLE
Deal with missing/case-insensitive currencies

### DIFF
--- a/currencies/views.py
+++ b/currencies/views.py
@@ -19,7 +19,8 @@ def set_currency(request):
             try:
                 currency = Currency.objects.get(code__iexact=currency_code)
             except Currency.DoesNotExist:
-                currency = currency_code
+                currency_code = None
+                currency = None
             request.session['currency'] = currency
         else:
             response.set_cookie('currency', currency_code)

--- a/currencies/views.py
+++ b/currencies/views.py
@@ -16,8 +16,11 @@ def set_currency(request):
     response = HttpResponseRedirect(next)
     if currency_code:
         if hasattr(request, 'session'):
-            request.session['currency'] = \
-                Currency.objects.get(code__exact=currency_code)
+            try:
+                currency = Currency.objects.get(code__iexact=currency_code)
+            except Currency.DoesNotExist:
+                currency = currency_code
+            request.session['currency'] = currency
         else:
             response.set_cookie('currency', currency_code)
     return response

--- a/currencies/views.py
+++ b/currencies/views.py
@@ -19,8 +19,7 @@ def set_currency(request):
             try:
                 currency = Currency.objects.get(code__iexact=currency_code)
             except Currency.DoesNotExist:
-                currency_code = None
-                currency = None
+                return HttpResponseRedirect(next)
             request.session['currency'] = currency
         else:
             response.set_cookie('currency', currency_code)


### PR DESCRIPTION
I get an error I try and call, say `http://www.madeup.com/currencies/setcurrency/?currency=jpy` (lowercase currency with uppercase code in database) or `http://www.madeup.com/currencies/setcurrency/?currency=completelymadeupcurrency` (non-existent currency)

The following should at least try and check for a currency before assigning it.