### PR TITLE
Other currency sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# OSX
+.DS_Store
+

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,40 @@ Configuration
 -------------
 
 django-currencies has built-in integration with
-`openexchangerates.org <http://openexchangerates.org/>`_.
+`openexchangerates.org <http://openexchangerates.org/>`_ and `Yahoo Finance <http://finance.yahoo.com/currency-converter/>`_.
+
+**Management Commands**
+
+You can use the management commands ``currencies`` and ``updatecurrencies``
+to maintain the currencies in the database. The former will import any
+currencies that are defined on the selected source. The latter will update
+all the database currencies against the rates returned by the source. Any
+currency missing on the source will be left untouched.
+
+You can selectively import currencies, for example the commands below
+will import USD and EUR currencies only, or use a variable from the
+settings that points to an iterable respectively:
+
+.. code-block:: shell
+
+    ./manage.py currencies --import=USD --import=EUR
+    ./manage.py currencies -i SHOP_CURRENCIES
+
+For more information on the additional switches ``--force`` and ``--verbosity``
+try ``./manage.py help currencies``.
+
+``updatecurrencies`` can automatically change the base rate of the imported
+exchange rates by specifying the ``--base`` switch like so:
+
+.. code-block:: shell
+
+    ./manage.py updatecurrencies oxr --base=USD
+    ./manage.py updatecurrencies yahoo -b SHOP_DEFAULT_CURRENCY
+
+**OpenExchangeRates**
+
+This is the default source or select it specifically using ``oxr`` as
+positional argument to either command.
 
 You will need to specify your API key in your settings file:
 
@@ -82,19 +115,9 @@ You will need to specify your API key in your settings file:
 
     OPENEXCHANGERATES_APP_ID = "c2b2efcb306e075d9c2f2d0b614119ea"
 
-You will then be able to use the management commands ``currencies``
-and ``updatecurrencies``. The former will import any currencies that
-are defined on `openexchangerates.org <http://openexchangerates.org/>`_.
-You can selectively import currencies, for example bellow command will
-import USD and EUR currencies only:
+**Yahoo Finance**
 
-.. code-block:: shell
-
-    ./manage.py currencies --import=USD --import=EUR
-
-The ``updatecurrencies`` management command will update all your
-currencies against the rates returned by `openexchangerates.org <http://openexchangerates.org/>`_.
-Any missing currency will be left untouched.
+Select this source by specifying ``yahoo`` as positional argument.
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -115,9 +115,15 @@ You will need to specify your API key in your settings file:
 
     OPENEXCHANGERATES_APP_ID = "c2b2efcb306e075d9c2f2d0b614119ea"
 
+Requirements: `OpenExchangeRatesClient <https://github.com/metglobal/openexchangerates>`_
+or one of the python3-compatible forks.
+
 **Yahoo Finance**
 
 Select this source by specifying ``yahoo`` as positional argument.
+
+Requirements: `BeautifulSoup4 <https://www.crummy.com/software/BeautifulSoup/bs4/doc/>`_
+and `requests <http://docs.python-requests.org/en/master/>`_
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,8 @@ settings that points to an iterable respectively:
     ./manage.py currencies --import=USD --import=EUR
     ./manage.py currencies -i SHOP_CURRENCIES
 
+The command automatically looks for variables CURRENCIES or SHOP_CURRENCIES
+in settings if ``-i`` is not specified.
 For more information on the additional switches ``--force`` and ``--verbosity``
 try ``./manage.py help currencies``.
 
@@ -103,6 +105,9 @@ exchange rates by specifying the ``--base`` switch like so:
 
     ./manage.py updatecurrencies oxr --base=USD
     ./manage.py updatecurrencies yahoo -b SHOP_DEFAULT_CURRENCY
+
+The command automatically looks for variables CURRENCIES_BASE or SHOP_DEFAULT_CURRENCY
+in settings if ``-b`` is not specified.
 
 **OpenExchangeRates**
 

--- a/currencies/management/commands/_currencyhandler.py
+++ b/currencies/management/commands/_currencyhandler.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+import os
+import json
+from decimal import Decimal
+
+class BaseHandler(object):
+    """
+    Base Currency Handler implements helpers:
+    info(), warn()
+    get_currencysymbol(code) - should be overridden
+    ratechangebase(Decimal, current_base, new_base)
+
+    Public API required:
+    endpoint
+    get_allcurrencycodes()
+    get_currencyname(code)
+    get_ratetimestamp(base, code)
+    get_ratefactor(base, code)
+    """
+
+    def __init__(self, print_info, print_warn):
+        """Save the message stream functions"""
+        self.info = print_info
+        self.warn = print_warn
+
+    _symbols = None
+    def get_currencysymbol(self, code):
+        """Retrieve the currency symbol from the local file"""
+        if not self._symbols:
+            symbolpath = os.path.join(os.path.dirname(__file__), 'currencies.json')
+            with open(symbolpath) as df:
+                self._symbols = json.load(df)
+        return self._symbols.get(code)
+
+    _multiplier = None
+    def ratechangebase(self, ratefactor, current_base, new_base):
+        """
+        Local helper function for changing currency base, returns new rate in new base
+        Defaults to ROUND_HALF_EVEN
+        """
+        if not self._multiplier:
+            self.warn("CurrencyHandler: changing base ourselves")
+            # Check the current base is 1
+            if Decimal(1) != self.get_ratefactor(current_base, current_base):
+                raise RuntimeError("CurrencyHandler: current baserate: %s not 1" % current_base)
+            self._multiplier = Decimal(1) / self.get_ratefactor(current_base, new_base)
+        return (ratefactor * self._multiplier).quantize(Decimal(".0001"))

--- a/currencies/management/commands/_openexchangerates.py
+++ b/currencies/management/commands/_openexchangerates.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+import sys
+from decimal import Decimal, getcontext
+from datetime import datetime
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from openexchangerates import OpenExchangeRatesClient, OpenExchangeRatesClientException
+
+# Initialisation
+APP_ID = getattr(settings, "OPENEXCHANGERATES_APP_ID", None)
+if APP_ID is None:
+    raise ImproperlyConfigured(
+        "You need to set the 'OPENEXCHANGERATES_APP_ID' setting to your openexchangerates.org api key")
+
+def get_handle(print_info, print_warn):
+    """
+    Get a handle to the currency client and description string
+    Passes helper functions for informational and warning messages
+    """
+    module = sys.modules[__name__]
+    setattr(module, 'info', print_info)
+    setattr(module, 'warn', print_warn)
+    client = OpenExchangeRatesClient(APP_ID)
+    return client, client.ENDPOINT_CURRENCIES
+
+currencies = None
+def get_allcurrencycodes(handle):
+    """Return an iterable of 3 character ISO 4217 currency codes"""
+    global currencies
+    currencies = handle.currencies()
+    return currencies.keys()
+
+def get_currencyname(handle, code):
+    """Return the currency name from the code"""
+    if not currencies:
+        get_allcurrencycodes(handle)
+    return currencies[code]
+
+rates = None
+def check_rates(rates, base):
+    """Local helper function for validating rates response"""
+
+    if "rates" not in rates:
+        raise RuntimeError("OpenExchangeRates: 'rates' not found in results")
+    if "base" not in rates or rates["base"] != base or base not in rates["rates"]:
+        warn("OpenExchangeRates: 'base' not found in results")
+
+def changebase(rates, current_base, new_base):
+    """
+    Local helper function for changing currency base, returns new rates
+    Defaults to ROUND_HALF_EVEN
+    """
+    check_rates(rates, current_base)
+    if new_base not in rates["rates"]:
+        raise RuntimeError("OpenExchangeRates: %s not found in rates whilst changing base" % new_base)
+
+    warn("OpenExchangeRates: changing base ourselves")
+    multiplier = Decimal(1) / rates["rates"][new_base]
+    for code, rate in rates["rates"].items():
+        rates["rates"][code] = (rate * multiplier).quantize(Decimal(".0001"))
+    rates["base"] = new_base
+    check_rates(rates, new_base)
+    return rates
+
+def get_latestcurrencyrates(handle, base):
+    """
+    Local helper function
+    Changing base is only available for paid-for plans, hence we do it ourselves
+    """
+    global rates
+    if not rates:
+        try:
+            rates = handle.latest(base=base)
+            check_rates(rates, base)
+        except OpenExchangeRatesClientException as e:
+            default_base = 'USD'
+            if str(e).startswith('403'):
+                rates = changebase(handle.latest(base=default_base), default_base, base)
+            else:
+                raise
+
+def get_ratetimestamp(handle, base):
+    """Return rate timestamp in datetime format"""
+    get_latestcurrencyrates(handle, base)
+    try:
+        return datetime.fromtimestamp(rates["timestamp"]).strftime("%Y-%m-%d %H:%M:%S")
+    except KeyError:
+        return None
+
+def get_ratefactor(handle, base, code):
+    """Return the Decimal currency exchange rate factor of 'code' compared to 1 'base' unit, or None"""
+    get_latestcurrencyrates(handle, base)
+    try:
+        return Decimal(rates["rates"][code])
+    except KeyError:
+        return None
+
+def remove_cache():
+    """Remove any cached data"""
+    global currencies, rates
+    currencies = rates = None

--- a/currencies/management/commands/_openexchangerates.py
+++ b/currencies/management/commands/_openexchangerates.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
-from decimal import Decimal, getcontext
+from decimal import Decimal
 from datetime import datetime
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -80,7 +80,7 @@ def get_latestcurrencyrates(handle, base):
             else:
                 raise
 
-def get_ratetimestamp(handle, base):
+def get_ratetimestamp(handle, base, code):
     """Return rate timestamp in datetime format"""
     get_latestcurrencyrates(handle, base)
     try:

--- a/currencies/management/commands/_yahoofinance.py
+++ b/currencies/management/commands/_yahoofinance.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import sys, re, json
-#from urllib2 import urlopen, HTTPError
 # requires beautifulsoup4 and requests
 from bs4 import BeautifulSoup as BS4
 from requests import get, exceptions
@@ -10,7 +9,7 @@ from datetime import datetime
 from ._currencyhandler import BaseHandler
 
 
-class YahooHandler(BaseHandler):
+class CurrencyHandler(BaseHandler):
     """
     Currency Handler implements public API:
     endpoint
@@ -90,7 +89,6 @@ class YahooHandler(BaseHandler):
         """Get a single rate, used as fallback"""
         try:
             url = self.onerate_url % (base, code)
-            #rate = urllib2.urlopen(url).read().rstrip()
             resp = get(url)
             resp.raise_for_status()
         except exceptions.HTTPError:
@@ -108,7 +106,16 @@ class YahooHandler(BaseHandler):
         return (currency['shortname'] for currency in self.currencies)
 
     def get_currency(self, code):
-        """Helper function"""
+        """
+        Helper function
+        Returns a dict containing:
+        shortname (the code)
+        longname
+        users - a comma separated list of countries/regions/cities that use it
+        alternatives - alternative names, e.g. ewro, Quid, Buck
+        symbol - e.g. £, $
+        highlight - ?
+        """
         for currency in self.currencies:
             if currency['shortname'] == code:
                 return currency
@@ -123,7 +130,10 @@ class YahooHandler(BaseHandler):
         return self.get_currency(code)['symbol']
 
     def get_rate(self, code):
-        """Helper function to access the rates structure"""
+        """
+        Helper function to access the rates structure
+        Returns a dict containing name, price, symbol (the code), timestamp, type, utctime & volume
+        """
         rateslist = self.rates['list']['resources']
         for rate in rateslist:
             rateobj = rate['resource']['fields']
@@ -182,29 +192,3 @@ class YahooHandler(BaseHandler):
             return ratefactor
         else:
             return self.ratechangebase(ratefactor, self.base, base)
-
-
-def get_handle(print_info, print_warn):
-    """
-    Get a handle to the currency client and description string
-    Passes helper functions for informational and warning messages
-    """
-    y = YahooHandler(print_info, print_warn)
-    return y, y.endpoint
-
-def get_allcurrencycodes(handle):
-    return handle.get_allcurrencycodes()
-
-def get_currencyname(handle, code):
-    return handle.get_currencyname(code)
-
-
-
-def get_ratetimestamp(handle, base, code):
-    return handle.get_ratetimestamp(base, code)
-
-def get_ratefactor(handle, base, code):
-    return handle.get_ratefactor(base, code)
-
-def remove_cache():
-    pass

--- a/currencies/management/commands/_yahoofinance.py
+++ b/currencies/management/commands/_yahoofinance.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+import sys, re, json
+#from urllib2 import urlopen, HTTPError
+# requires beautifulsoup4 and requests
+from bs4 import BeautifulSoup as BS4
+from requests import get, exceptions
+from decimal import Decimal
+from datetime import datetime
+
+from ._currencyhandler import BaseHandler
+
+
+class YahooHandler(BaseHandler):
+    """
+    Currency Handler implements public API:
+    endpoint
+    get_allcurrencycodes()
+    get_currencyname(code)
+    get_currencysymbol(code) - optional
+    get_ratetimestamp(base, code)
+    get_ratefactor(base, code)
+    """
+    endpoint = 'http://finance.yahoo.com'
+    onerate_url = 'http://finance.yahoo.com/d/quotes.csv?s=%s%s=X&f=l1'
+    full_url = 'http://uk.finance.yahoo.com/webservice/v1/symbols/allcurrencies/quote;currency=true?view=basic&format=json&callback=YAHOO.Finance.CurrencyConverter.addConversionRates'
+    ukbulk_url = 'http://uk.finance.yahoo.com/webservice/v1/symbols/allcurrencies/quote?format=json'
+    bulk_url = 'http://finance.yahoo.com/webservice/v1/symbols/allcurrencies/quote?format=json'
+    currencies_url = 'http://finance.yahoo.com/currency-converter/'
+
+    _currencies = None
+    _rates = None
+    _base = None
+
+    @property
+    def currencies(self):
+        if not self._currencies:
+            self._currencies = self.get_bulkcurrencies()
+        return self._currencies
+
+    @property
+    def rates(self):
+        if not self._rates:
+            self._rates = self.get_bulkrates()
+        return self._rates
+
+    @property
+    def base(self):
+        if not self._base:
+            self._base = self.get_baserate()
+        return self._base
+
+    def get_bulkcurrencies(self):
+        """
+        Get the supported currencies
+        Scraped from a JSON object on the html page in javascript tag
+        """
+        start = r'YAHOO\.Finance\.CurrencyConverter\.addCurrencies\('
+        _json = r'\[[^\]]*\]'
+        try:
+            resp = get(self.currencies_url)
+            resp.raise_for_status()
+        except exceptions.RequestException as e:
+            raise RuntimeError(e)
+        # Find the javascript that contains the json object
+        soup = BS4(resp.text, 'html.parser')
+        re_start = re.compile(start)
+        jscript = soup.find('script', type='text/javascript', text=re_start).string
+
+        # Separate the json object
+        re_json = re.compile(_json)
+        match = re_json.search(jscript)
+        if match:
+            json_str = match.group(0)
+        else:
+            raise RuntimeError("YahooFinance: Currency JSON object not found")
+
+        # Parse the json object
+        return json.loads(json_str)
+
+    def get_bulkrates(self):
+        """Get & format the rates dict"""
+        try:
+            resp = get(self.bulk_url)
+            resp.raise_for_status()
+        except exceptions.RequestException as e:
+            raise RuntimeError(e)
+        return resp.json()
+
+    def get_singlerate(self, base, code):
+        """Get a single rate, used as fallback"""
+        try:
+            url = self.onerate_url % (base, code)
+            #rate = urllib2.urlopen(url).read().rstrip()
+            resp = get(url)
+            resp.raise_for_status()
+        except exceptions.HTTPError:
+            self.warn("YahooFinance: problem with %s" % url)
+            return None
+        rate = resp.text.rstrip()
+
+        if rate == 'N/A':
+            return None
+        else:
+            return Decimal(rate)
+
+    def get_allcurrencycodes(self):
+        """Return an iterable of 3 character ISO 4217 currency codes"""
+        return (currency['shortname'] for currency in self.currencies)
+
+    def get_currency(self, code):
+        """Helper function"""
+        for currency in self.currencies:
+            if currency['shortname'] == code:
+                return currency
+        raise RuntimeError("YahooFinance: %s not found" % code)
+
+    def get_currencyname(self, code):
+        """Return the currency name from the code"""
+        return self.get_currency(code)['longname']
+
+    def get_currencysymbol(self, code):
+        """Return the currency symbol from the code"""
+        return self.get_currency(code)['symbol']
+
+    def get_rate(self, code):
+        """Helper function to access the rates structure"""
+        rateslist = self.rates['list']['resources']
+        for rate in rateslist:
+            rateobj = rate['resource']['fields']
+            if rateobj['symbol'].startswith(code):
+                return rateobj
+        raise RuntimeError("YahooFinance: %s not found" % code)
+
+    def get_baserate(self):
+        """Helper function to populate the base rate"""
+        rateslist = self.rates['list']['resources']
+        for rate in rateslist:
+            rateobj = rate['resource']['fields']
+            if rateobj['symbol'].partition('=')[0] == rateobj['name']:
+                return rateobj['name']
+        raise RuntimeError("YahooFinance: baserate not found")
+
+    def get_ratetimestamp(self, base, code):
+        """Return rate timestamp in datetime format or None"""
+        try:
+            ts = int(self.get_rate(code)['ts'])
+        except RuntimeError:
+            return None
+        return datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
+
+    # These YF currencies are reported differently with no base, but still appear to be based on USD
+    # Gold, Copper, Palladium, Platinum, Silver
+    _exceptions = ('XAU', 'XCP', 'XPD', 'XPT', 'XAG')
+    def check_ratebase(self, rate):
+        """Helper function"""
+        split = rate['name'].partition('/')
+        if split[1]:
+            ratebase = split[0]
+            if ratebase != self.base:
+                raise RuntimeError("YahooFinance: %s has different base rate:\n%s" % (ratebase, rate))
+        elif rate['name'] == self.base:
+            pass
+        elif rate['symbol'].partition('=')[0] not in self._exceptions:
+            self.warn("YahooFinance: currency found with no base:\n%s" % rate)
+
+
+    def get_ratefactor(self, base, code):
+        """
+        Return the Decimal currency exchange rate factor of 'code' compared to 1 'base' unit, or None
+        Yahoo currently uses USD as base currency, but here we detect it with get_baserate
+        """
+        try:
+            rate = self.get_rate(code)
+        except RuntimeError:
+            # fallback
+            return self.get_singlerate(base, code)
+
+        self.check_ratebase(rate)
+        ratefactor = Decimal(rate['price'])
+
+        if base == self.base:
+            return ratefactor
+        else:
+            return self.ratechangebase(ratefactor, self.base, base)
+
+
+def get_handle(print_info, print_warn):
+    """
+    Get a handle to the currency client and description string
+    Passes helper functions for informational and warning messages
+    """
+    y = YahooHandler(print_info, print_warn)
+    return y, y.endpoint
+
+def get_allcurrencycodes(handle):
+    return handle.get_allcurrencycodes()
+
+def get_currencyname(handle, code):
+    return handle.get_currencyname(code)
+
+
+
+def get_ratetimestamp(handle, base, code):
+    return handle.get_ratetimestamp(base, code)
+
+def get_ratefactor(handle, base, code):
+    return handle.get_ratefactor(base, code)
+
+def remove_cache():
+    pass

--- a/currencies/management/commands/currencies.py
+++ b/currencies/management/commands/currencies.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
-import json
 from collections import OrderedDict
 from importlib import import_module
 from django.conf import settings
@@ -17,17 +15,6 @@ sources = OrderedDict([
     #('google', '._googlecalculator.py'),
     #('ecb', '._europeancentralbank.py'),
 ])
-
-
-symbols = None
-def get_symbol(code):
-    """Retrieve the currency symbol from the local file"""
-    global symbols
-    if not symbols:
-        symbolpath = os.path.join(os.path.dirname(__file__), 'currencies.json')
-        with open(symbolpath) as df:
-            symbols = json.load(df)
-    return symbols.get(code)
 
 
 class Command(BaseCommand):

--- a/currencies/management/commands/currencies.py
+++ b/currencies/management/commands/currencies.py
@@ -33,13 +33,22 @@ class Command(BaseCommand):
         parser.add_argument('--force', '-f', action='store_true', default=False,
             help='Update database even if currency already exists')
         parser.add_argument('--import', '-i', action='append', default=[],
-            help=(  'Selectively import currencies by supplying the currency codes (e.g. USD) one per switch '
-                    'or supply an uppercase settings variable name with an iterable (once only).'))
+            help=   'Selectively import currencies by supplying the currency codes (e.g. USD) one per switch, '
+                    'or supply an uppercase settings variable name with an iterable (once only), '
+                    'or looks for settings CURRENCIES or SHOP_CURRENCIES.')
 
     def get_imports(self, option):
-        """See if we have been passed a set of currencies or a setting variable"""
+        """
+        See if we have been passed a set of currencies or a setting variable
+        or look for settings CURRENCIES or SHOP_CURRENCIES.
+        """
         if not option:
-            self.stderr.write("No imports found. Some currencies may be out-of-date (MTL) or spurious (XPD)")
+            for attr in ('CURRENCIES', 'SHOP_CURRENCIES'):
+                try:
+                    return getattr(settings, attr)
+                except AttributeError:
+                    continue
+            self.stderr.write("Importing all. Some currencies may be out-of-date (MTL) or spurious (XPD)")
             return option
         elif len(option) == 1 and option[0].isupper() and len(option[0]) != 3:
             return getattr(settings, option[0])

--- a/currencies/management/commands/updatecurrencies.py
+++ b/currencies/management/commands/updatecurrencies.py
@@ -13,16 +13,26 @@ class Command(CurrencyCommand):
         """Add command arguments"""
         parser.add_argument(self._source_param, **self._source_kwargs)
         parser.add_argument('--base', '-b', action='store',
-            help='Supply the base currency as code or settings variable name; default is taken from the db, otherwise USD')
+            help=   'Supply the base currency as code or a settings variable name. '
+                    'The default is taken from settings CURRENCIES_BASE or SHOP_DEFAULT_CURRENCY, '
+                    'or the db, otherwise USD')
 
     def get_base(self, option):
-        """Parse the base command option. Can be supplied as a 3 character code or a settings variable name"""
+        """
+        Parse the base command option. Can be supplied as a 3 character code or a settings variable name
+        If base is not supplied, looks for settings CURRENCIES_BASE and SHOP_DEFAULT_CURRENCY
+        """
         if isinstance(option, str) and option.isupper():
             if len(option) == 3:
                 return option, True
             else:
                 return getattr(settings, option), True
         else:
+            for attr in ('CURRENCIES_BASE', 'SHOP_DEFAULT_CURRENCY'):
+                try:
+                    return getattr(settings, attr), True
+                except AttributeError:
+                    continue
             return 'USD', False
 
     def handle(self, *args, **options):

--- a/currencies/management/commands/updatecurrencies.py
+++ b/currencies/management/commands/updatecurrencies.py
@@ -72,10 +72,6 @@ class Command(CurrencyCommand):
         if verbose >= 1:
             self.stdout.write("Querying database at %s" % endpoint)
 
-        timestamp = self.get_ratetimestamp(handle, base)
-        if verbose >= 1 and timestamp:
-            self.stdout.write("Rates last updated at %s" % timestamp)
-
         for obj in Currency._default_manager.all():
             rate = self.get_ratefactor(handle, base, obj.code)
             if not rate:
@@ -85,7 +81,11 @@ class Command(CurrencyCommand):
             factor = rate.quantize(Decimal(".0001"))
             if obj.factor != factor:
                 if verbose >= 1:
-                    self.stdout.write("Updating %s rate to %f" % (obj, factor))
+                    update_str = ""
+                    timestamp = self.get_ratetimestamp(handle, base, obj.code)
+                    if timestamp:
+                        update_str = ", updated at %s" % timestamp
+                    self.stdout.write("Updating %s rate to %f%s" % (obj, factor, update_str))
 
                 Currency._default_manager.filter(pk=obj.pk).update(factor=factor)
         self.remove_cache()

--- a/currencies/migrations/0002_alter_model.py
+++ b/currencies/migrations/0002_alter_model.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='currency',
             name='name',
-            field=models.CharField(unique=True, max_length=35, verbose_name='name', db_index=True),
+            field=models.CharField(max_length=35, verbose_name='name', db_index=True),
         ),
         migrations.AlterField(
             model_name='currency',

--- a/currencies/models.py
+++ b/currencies/models.py
@@ -13,7 +13,7 @@ class Currency(models.Model):
     code = models.CharField(_('code'), max_length=3,
                             unique=True, db_index=True)
     name = models.CharField(_('name'), max_length=35,
-                            unique=True, db_index=True)
+                            db_index=True)
     symbol = models.CharField(_('symbol'), max_length=4, blank=True,
                               db_index=True)
     factor = models.DecimalField(_('factor'), max_digits=30, decimal_places=10, default=1.0,


### PR DESCRIPTION
Hi, I've completely refactored the management commands (maintaining backward compatibility of course) to add in some new features and Yahoo Finance integration. New features and advantages:
- An alternative to being tied into openexchangerates
- YF provides symbols so you don't have to keep a file up-to-date
- Added ability to get the list of currencies from settings
- Added ability to get the desired base rate flag from settings
- Automatic DB base rate change (even with a free oxr account)
- Simple to add Google Calculator, ECB, etc handlers
- I'll also update the documentation..

Downsides:
- I've had to scrape the YF content and I guess there's no guarantee that things will stay where they are now
- I've only tested on Django 1.9.9, BeautifulSoup 4.4.0, requests 2.11.1, urllib3 1.12, openexchangerates 0.1.1 and python 3.5.2
- I haven't written any test cases

Happy to take feedback if there are any major headaches in there but really need to get back to the 'day job' ;) Would love to see this merged!

[Check it out!](https://github.com/racitup/django-currencies)
