### PR TITLE
Remove disutils parsing error on requires keyword

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     ],    
     requires=[
         'Django (>=1.4.2)',
-        'django-jsonfield (>=1.0.3)',
+        'djangojsonfield (>=1.0.3)',
     ],
     
     description='Adds support for multiple currencies as a Django application.',


### PR DESCRIPTION
This PR addresses the problems in issue #47 regarding disutils parsing the `-` character as an operator in the `requires` keyword.  Alternatively, we could also delete the requires keyword altogether.