### PR TITLE
use install_requires instead of requires

### DIFF
--- a/currencies/management/commands/currencies.py
+++ b/currencies/management/commands/currencies.py
@@ -21,7 +21,7 @@ sources = OrderedDict([
 class Command(BaseCommand):
     help = "Create all missing db currencies available from the chosen source"
 
-    _package_name = __loader__.name.rsplit('.', 1)[0]
+    _package_name = __name__.rsplit('.', 1)[0]
     _source_param = 'source'
     _source_default = next(iter(sources))
     _source_kwargs = {'action': 'store', 'nargs': '?', 'default': _source_default,

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,10 @@ setup(
         'django>=1.4.2',
         'jsonfield>=1.0.3',
     ],    
-    requires=[
-        'Django (>=1.4.2)',
-        'django-jsonfield (>=1.0.3)',
-    ],
+    #requires=[
+    #    'Django (>=1.4.2)',
+    #    'django-jsonfield (>=1.0.3)',
+    #],
     
     description='Adds support for multiple currencies as a Django application.',
     long_description=read('README.rst'),


### PR DESCRIPTION
```django-jsonfield (>=1.0.3)``` fails with ```ValueError: expected parenthesized list: '-jsonfield (>=1.0.3)'```