### PR TITLE
Unicode issue resolved.

### DIFF
--- a/currencies/management/commands/_yahoofinance.py
+++ b/currencies/management/commands/_yahoofinance.py
@@ -78,7 +78,7 @@ class CurrencyHandler(BaseHandler):
             if match:
                 json_str = match.group(0)
                 with open(self._cached_currency_file, 'w') as fd:
-                    fd.write(json_str)
+                    fd.write(json_str.encode('utf-8'))
 
         # Parse the json file
         with open(self._cached_currency_file, 'r') as fd:


### PR DESCRIPTION
When running ./manage.py currencies yahoo --import='USD'
Throws this error
UnicodeEncodeError: 'ascii' codec can't encode character u'\u20ac' in position 774: ordinal not in range(128)

So to write to json file, set encoding type to utf-8