### PR TITLE
make utils.py work with cached queryset results dict

### DIFF
--- a/currencies/models.py
+++ b/currencies/models.py
@@ -4,6 +4,7 @@ from six import python_2_unicode_compatible
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from jsonfield.fields import JSONField
+from django.core.cache import cache
 
 from .managers import CurrencyManager
 
@@ -52,5 +53,8 @@ class Currency(models.Model):
         # Make sure default / base currency is active
         if self.is_default or self.is_base:
             self.is_active = True
+
+        cache_key = 'django-currencies-active'
+        cache.delete(cache_key)
 
         super(Currency, self).save(**kwargs)

--- a/currencies/utils.py
+++ b/currencies/utils.py
@@ -1,32 +1,38 @@
 # -*- coding: utf-8 -*-
 from decimal import Decimal as D, InvalidOperation, ROUND_UP
+from django.forms.models import model_to_dict
+from django.core.cache import cache
+
 from .models import Currency as C
 from .conf import SESSION_KEY
 
 
-def get_active_currencies_qs():
-    return C.active.defer('info').all()
 
 
 def calculate(price, to_code, **kwargs):
     """Converts a price in the default currency to another currency"""
-    qs = kwargs.get('qs', get_active_currencies_qs())
-    kwargs['qs'] = qs
-    default_code = qs.default().code
+    # qs = kwargs.get('qs', get_active_currencies_qs())
+    # kwargs['qs'] = qs
+    # default_code = qs.default().code
+    default_code = get_default_currency()['code']
     return convert(price, default_code, to_code, **kwargs)
 
 
-def convert(amount, from_code, to_code, decimals=2, qs=None):
+def convert(amount, from_code, to_code, decimals=2,):
     """Converts from any currency to any currency"""
     if from_code == to_code:
         return amount
 
-    if qs is None:
-        qs = get_active_currencies_qs()
+    # if qs is None:
+        # qs = get_active_currencies_qs()
+    
+    qs = get_currencies_dict()
 
-    from_, to = qs.get(code=from_code), qs.get(code=to_code)
+    # from_, to = qs.get(code=from_code), qs.get(code=to_code)
+    from_, to = qs[from_code], qs[to_code]
 
-    amount = D(amount) * (to.factor / from_.factor)
+    # amount = D(amount) * (to.factor / from_.factor)
+    amount = D(amount) * (to['factor'] / from_['factor'])
     return price_rounding(amount, decimals=decimals)
 
 
@@ -39,10 +45,11 @@ def get_currency_code(request):
                 continue
 
     # fallback to default...
-    try:
-        return C.active.default().code
-    except C.DoesNotExist:
-        return None  # shit happens...
+    # try:
+    #     return C.active.default().code
+    # except C.DoesNotExist:
+    #     return None  # shit happens...
+    return get_default_currency()['code']
 
 
 def price_rounding(price, decimals=2):
@@ -53,3 +60,35 @@ def price_rounding(price, decimals=2):
         # Currencies with no decimal places, ex. JPY, HUF
         exponent = D()
     return price.quantize(exponent, rounding=ROUND_UP)
+
+
+def get_default_currency():
+    currencies = get_currencies_dict()
+    for code, cur in currencies.items():
+        if cur['is_default']:
+            return cur
+    return None  # shit happens...
+
+
+def get_currencies_dict():
+    cache_key = 'django-currencies-active'
+    result = cache.get(cache_key)
+    if result is None:
+        # print('--- --- cache not found, DB iterating.....')
+
+        qs = C.active.defer('info').all()
+
+        result = {}
+        for cur in qs:
+            result[cur.code] = model_to_dict(cur, fields=('code','name','symbol','factor','is_base','is_default',))
+
+        cache.set(cache_key, result, 3600 * 1)  # 1 Hour (This cache var unset on every model change)
+
+    # print('--- get_currencies_dict() result =', result)
+
+    return result
+
+
+def get_active_currencies_qs():
+    return C.active.defer('info').all()
+


### PR DESCRIPTION
This will protect from DB query for each `currency` filter usage (1 query per hour, until model would not be changed)