### PR TITLE
Allow jsonfield 3.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
 
     install_requires=[
         'django>=1.8',
-        'jsonfield>=1.0.3,<3.0.0',
+        'jsonfield>=1.0.3,<=3.1.0',
         'requests>=2.14.2',
         'bs4',
     ],


### PR DESCRIPTION
There doesn't seem to be any breaking changes with jsonfield 3.1.0: https://github.com/rpkilby/jsonfield/blob/master/CHANGES.rst#v310-02222020

I just tested the rate update with this fork and everything seems to work fine with jsonfield 3.1.0.